### PR TITLE
Leader curator

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+label="upgrade-marathon-1.6-b15e455"
+image="docker.strava.com/strava/bamboo:${label}"
+echo $image
+docker build -t $image .
+docker push $image

--- a/configuration/marathon.go
+++ b/configuration/marathon.go
@@ -33,7 +33,7 @@ func (m Marathon) Endpoints() []string {
 func zkEndpoints(zkConf Zookeeper) ([]string, error) {
 	// Only tested with marathon 0.11.1, assumes http:// for marathon
 	const scheme = "http://"
-	const leaderNode = "leader"
+	const leaderNode = "leader-curator"
 
 	conn, _, err := zk.Connect(zkConf.ConnectionString(), time.Second*10)
 


### PR DESCRIPTION
New marathon uses `leader-curator` in bamboo rather than `leader`